### PR TITLE
[FE] API 수정 및 레이블/마일스톤 페이지간 공유하는 버튼 토글 버그 수정

### DIFF
--- a/frontend/src/components/Labels/Labels.jsx
+++ b/frontend/src/components/Labels/Labels.jsx
@@ -10,14 +10,23 @@ import {
 	labelAddButtonFlagState,
 	labelCountState,
 	labelUpdateState,
+	milestoneAddButtonFlagState,
+	navigatorAddButtonFlagState,
 } from "RecoilStore/Atoms";
-import { useRecoilValue, useRecoilState } from "recoil";
+import { useRecoilValue, useRecoilState, useSetRecoilState } from "recoil";
 
 const Labels = () => {
 	const [initialData, setLabelInitialData] = useRecoilState(labelInitialData);
 	const labelAddBtnFlag = useRecoilValue(labelAddButtonFlagState);
 	const [labelCount, setLabelCount] = useRecoilState(labelCountState);
 	const forceUpdate = useRecoilValue(labelUpdateState);
+	const setMilestoneAddBtnFlag = useSetRecoilState(milestoneAddButtonFlagState);
+	const setNavigatorAddBtnFlag = useSetRecoilState(navigatorAddButtonFlagState);
+
+	useEffect(() => {
+		setNavigatorAddBtnFlag(false);
+		setMilestoneAddBtnFlag(false);
+	}, []);
 
 	const getLabelData = async () => {
 		const { labels } = await fetchData(API.labels(), "GET");

--- a/frontend/src/components/Milestones/MilestoneInput.jsx
+++ b/frontend/src/components/Milestones/MilestoneInput.jsx
@@ -1,11 +1,12 @@
 import styled from "styled-components";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AddButton from "components/common/Button/BlueButtons";
 import API from "util/API";
 import { useSetRecoilState, useRecoilState } from "recoil";
 import {
 	milestoneAddButtonFlagState,
 	milestoneUpdateState,
+	navigatorAddButtonFlagState,
 } from "RecoilStore/Atoms";
 import fetchData from "util/fetchData";
 
@@ -22,28 +23,29 @@ const MilestoneInput = ({
 		dueDate: dueDate,
 		description: description,
 	});
-	const setMilestoneAddButtonFlag = useSetRecoilState(
+	const [milestoneAddButtonFlag, setMilestoneAddButtonFlag] = useRecoilState(
 		milestoneAddButtonFlagState
 	);
+	const setNavigatorAddBtnFlag = useSetRecoilState(navigatorAddButtonFlagState);
 	const [update, forceUpdate] = useRecoilState(milestoneUpdateState);
-
 	const [titleInput, setTitleInput] = useState(title);
 	const [dateInput, setDateInput] = useState(dueDate);
 	const [descInput, setDescInput] = useState(description);
 
 	const putMilestone = async () => {
-		await fetchData(API.milestonesId(id), "PUT", inputData);
 		setMilestoneAddButtonFlag(false);
+		await fetchData(API.milestonesId(id), "PUT", inputData);
 		setEditMode(false);
 		forceUpdate();
 	};
 
 	const postMilestone = async () => {
-		await fetchData(API.milestones(), "POST", inputData);
 		setMilestoneAddButtonFlag(false);
+		setNavigatorAddBtnFlag(x => !x);
+		await fetchData(API.milestones(), "POST", inputData);
 	};
 
-	const handleTitleChange = (e) => {
+	const handleTitleChange = e => {
 		setTitleInput(e.target.value);
 		setInputData({
 			...inputData,
@@ -51,7 +53,7 @@ const MilestoneInput = ({
 		});
 	};
 
-	const handleDateChange = (e) => {
+	const handleDateChange = e => {
 		setDateInput(e.target.value);
 		setInputData({
 			...inputData,
@@ -59,15 +61,13 @@ const MilestoneInput = ({
 		});
 	};
 
-	const handleDescChange = (e) => {
+	const handleDescChange = e => {
 		setDescInput(e.target.value);
 		setInputData({
 			...inputData,
 			description: e.target.value,
 		});
 	};
-
-	console.log(editMode);
 
 	return (
 		<CardWrapper>

--- a/frontend/src/components/Milestones/Milestones.jsx
+++ b/frontend/src/components/Milestones/Milestones.jsx
@@ -5,14 +5,18 @@ import MilestoneInput from "./MilestoneInput";
 import {
 	milestoneAddButtonFlagState,
 	milestoneCountState,
+	labelAddButtonFlagState,
+	navigatorAddButtonFlagState,
 } from "RecoilStore/Atoms";
 import { useSetRecoilState, useRecoilValue } from "recoil";
 import API from "util/API";
 import fetchData from "util/fetchData";
 
 const Milestones = () => {
-	const milestoneAddBtn = useRecoilValue(milestoneAddButtonFlagState);
 	const [milestone, setMilestone] = useState();
+	const milestoneAddBtn = useRecoilValue(milestoneAddButtonFlagState);
+	const setNavigatorAddBtn = useSetRecoilState(navigatorAddButtonFlagState);
+	const setLabelAddBtnFlag = useSetRecoilState(labelAddButtonFlagState);
 	const setMilestoneCount = useSetRecoilState(milestoneCountState);
 
 	const fetchMilestones = async () => {
@@ -20,6 +24,11 @@ const Milestones = () => {
 		setMilestone(milestones);
 		setMilestoneCount(milestones.length);
 	};
+
+	useEffect(() => {
+		setNavigatorAddBtn(false);
+		setLabelAddBtnFlag(false);
+	}, []);
 
 	useEffect(() => {
 		fetchMilestones();
@@ -30,11 +39,11 @@ const Milestones = () => {
 			{milestoneAddBtn ? (
 				<>
 					<MilestoneInput />
-					<MilestonesHeader />
 				</>
 			) : (
 				<></>
 			)}
+			<MilestonesHeader />
 			{milestone &&
 				milestone.map((milestone, i) => (
 					<MilestoneCard key={i} data={milestone} />

--- a/frontend/src/components/Milestones/MilestonesHeader.jsx
+++ b/frontend/src/components/Milestones/MilestonesHeader.jsx
@@ -33,7 +33,7 @@ export default MilestonesHeader;
 const Contents = styled.div`
 	display: flex;
 	justify-content: space-between;
-	width: 30%;
+	width: 20%;
 	align-items: center;
 `;
 

--- a/frontend/src/components/common/Navigator.jsx
+++ b/frontend/src/components/common/Navigator.jsx
@@ -43,10 +43,15 @@ const Navigator = () => {
 	//Refactoring
 	//리렌더 2번 일어남
 	const handleClick = () => {
-		milestoneFlag
-			? setMilestoneAddBtnFlag(!milestoneAddBtnFlag)
-			: setLabelAddBtnFlag(!labelAddBtnFlag);
-		setAddButtonFlag(!addButtonFlag);
+		if (milestoneFlag) {
+			setMilestoneAddBtnFlag(!milestoneAddBtnFlag);
+			setLabelAddBtnFlag(false);
+			setAddButtonFlag(!addButtonFlag);
+		} else {
+			setLabelAddBtnFlag(!labelAddBtnFlag);
+			setMilestoneAddBtnFlag(false);
+			setAddButtonFlag(!addButtonFlag);
+		}
 	};
 
 	return (

--- a/frontend/src/util/API.js
+++ b/frontend/src/util/API.js
@@ -6,7 +6,7 @@ const API = {
 		return `${this.default()}/login/github/web?code=${code}`;
 	},
 	gitHubOAuth() {
-		return "https://github.com/login/oauth/authorize?client_id=c39689919134be7915cf&redirect_uri=http://localhost:3000/login";
+		return "https://github.com/login/oauth/authorize?client_id=0aa5fde2597879720f8c&redirect_uri=http://localhost:3000/login";
 	},
 	issues() {
 		return `${this.default()}/issues`;

--- a/frontend/src/util/API.js
+++ b/frontend/src/util/API.js
@@ -1,6 +1,6 @@
 const API = {
 	default() {
-		return "http://13.125.197.4/api";
+		return "http://3.36.131.167/api";
 	},
 	login(code) {
 		return `${this.default()}/login/github/web?code=${code}`;


### PR DESCRIPTION
## 데이지!! 코드 보시고 문제없다 싶으시면 머지 부탁드려요!! 문제있음 언제든 DM주십쇼!!
### 버그 수정을 위해 데이지랑 공유하는 Navigator.jsx 랑 데이지가 작업하신 Labels.jsx 에 제가 코드를 조금 보탰습니다.


### 수정사항
* K 가 서버를 새로 열어주셔서, 해당 서버에 맞게 코드 내 API 와 OAuth CliendID 를 수정했습니다. 
* 마일스톤/레이블 페이지를 이동할 때 추가 버튼이 초기화되도록 Navigator.jsx 의 handleClick 함수를 수정했습니다.
* 마일스톤/레이블 페이지가 열릴 때 반대 페이지의 인풋 창이 닫히도록 Milestones.jsx 와 Labels.jsx 컴포넌트 내에 useEffect를 추가했습니다.