### PR TITLE
[FE] issue detail page

### DIFF
--- a/frontend/src/RecoilStore/Atoms.jsx
+++ b/frontend/src/RecoilStore/Atoms.jsx
@@ -95,6 +95,25 @@ export const milestoneCategoryState = atom({
 	key: "milestoneCategoryState",
 	default: {},
 });
+//현재 클릭된 카테고리가 담김. set을 통해 리셋 가능
+export const categorySelectorState = selector({
+	key: "categorySelectorState",
+	get: ({ get }) => {
+		const assignee = get(assigneeCategoryState);
+		const label = get(labelCategoryState);
+		const milestone = get(milestoneCategoryState);
+		return {
+			assignee: assignee,
+			label: label,
+			milestone: milestone,
+		};
+	},
+	set: ({ set }) => {
+		set(assigneeCategoryState, []);
+		set(labelCategoryState, []);
+		set(milestoneCategoryState, {});
+	},
+});
 
 export const commentInputState = atom({
 	key: "commentInputState",

--- a/frontend/src/components/NewIssues/NewIssueForm.jsx
+++ b/frontend/src/components/NewIssues/NewIssueForm.jsx
@@ -8,43 +8,25 @@ import getUserInfo from "util/getUserInfo";
 import {
 	commentInputState,
 	categoryIdSelectorState,
-	assigneeCategoryState,
-	labelCategoryState,
-	milestoneCategoryState,
+	categorySelectorState,
 } from "RecoilStore/Atoms";
-import { useRecoilValue, useResetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useState } from "react";
 import fetchData from "util/fetchData";
 import API from "util/API";
 
 const NewIssueForm = () => {
 	const userInfo = getUserInfo();
-
-	const resetAssigneeCategoryState = useResetRecoilState(assigneeCategoryState);
-	const resetLabelCategoryState = useResetRecoilState(labelCategoryState);
-	const resetMilestoneCategoryState = useResetRecoilState(
-		milestoneCategoryState
-	);
-
+	const resetCategory = useSetRecoilState(categorySelectorState);
 	const [issueTitle, setIssueTitle] = useState("");
 	const commentValue = useRecoilValue(commentInputState);
 	const categoryId = useRecoilValue(categoryIdSelectorState);
-	const handleTitleInput = (e) => {
+	const handleTitleInput = e => {
 		setIssueTitle(e.target.value);
 	};
 
 	const handleSubmit = async () => {
-		console.log(categoryId);
 		const { assignee, label, milestone } = categoryId;
-		// title : issueTitle
-		// comment : commentValue.content
-		// 	{
-		// 		"title" : "[BE] Issue 등록",
-		// 		"comment" : "코멘트",
-		// 		"assigneeIds" : ["e33d0533-db20-4e46-b0d0-61cb2217c09e"],
-		// 		"labelIds" : ["6f5a0331-2d8c-40b8-a869-bd777858d631"],
-		// 		"milestoneId" : "dd3a87c5-b290-4794-9914-29df1f58533d"
-		// }
 		const requestBody = {
 			title: issueTitle,
 			comment: commentValue.content,
@@ -52,13 +34,8 @@ const NewIssueForm = () => {
 			labelIds: label,
 			milestoneId: milestone,
 		};
-		const res = await fetchData(API.issues(), "POST", requestBody);
-		console.log(res);
-		resetAssigneeCategoryState();
-		resetLabelCategoryState();
-		resetMilestoneCategoryState();
-		//상태 리셋하기
-		// 이슈 상세페이지로 가기
+		await fetchData(API.issues(), "POST", requestBody);
+		resetCategory();
 	};
 
 	return (
@@ -101,8 +78,6 @@ const NewIssueForm = () => {
 		</>
 	);
 };
-
-export default NewIssueForm;
 
 const Wrapper = styled.div`
 	display: grid;
@@ -149,9 +124,8 @@ const Input = styled.input`
 `;
 
 const CancelBtn = styled.div`
-	/* display: flex;
-	align-items: center;
-	justify-content: space-between; */
 	align-self: center;
 	margin-right: 1rem;
 `;
+
+export default NewIssueForm;

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -2,12 +2,18 @@ import styled from "styled-components";
 import { ReactComponent as Logo } from "images/LogotypeMedium.svg";
 import { Link } from "react-router-dom";
 import getUserInfo from "util/getUserInfo";
-
+import { categorySelectorState } from "RecoilStore/Atoms";
+import { useSetRecoilState } from "recoil";
 const Header = () => {
 	const userInfo = getUserInfo();
+	const resetCategoryValue = useSetRecoilState(categorySelectorState);
+
+	const handleClick = () => {
+		resetCategoryValue();
+	};
 
 	return (
-		<StyleHeader>
+		<StyleHeader onClick={handleClick}>
 			<Link to="/main">
 				<Logo />
 			</Link>

--- a/frontend/src/components/common/IssueCategory/IssueCategoryModal.jsx
+++ b/frontend/src/components/common/IssueCategory/IssueCategoryModal.jsx
@@ -13,7 +13,6 @@ import { useRecoilState, useResetRecoilState } from "recoil";
 import fetchData from "util/fetchData";
 import API from "util/API";
 const IssueCategoryModal = ({ category, data }) => {
-	//이 아래 3 상태 다른 페이지 넘어갈때 리셋되게 해야함(메인,편집,새 이슈)
 	const [assigneeCategory, setAssigneeCategory] = useRecoilState(
 		assigneeCategoryState
 	);
@@ -21,8 +20,6 @@ const IssueCategoryModal = ({ category, data }) => {
 	const [milestoneCategory, setMilestoneCategory] = useRecoilState(
 		milestoneCategoryState
 	);
-
-	// 초기 화면 렌더링 시 카테고리 모달 상태 초기화
 
 	//아래 코드는 리팩토링 예정!!!-----중복코드---------------------------
 	const handleCheckAssignee = e => {
@@ -36,14 +33,7 @@ const IssueCategoryModal = ({ category, data }) => {
 			setAssigneeCategory(newAssigneeCategory);
 		}
 		if (assigneeCategory.every(x => x.id !== targetId)) {
-			setAssigneeCategory([
-				...assigneeCategory,
-				{
-					id: targetData.id,
-					githubId: targetData.githubId,
-					imageUrl: targetData.imageUrl,
-				},
-			]);
+			setAssigneeCategory([...assigneeCategory, targetData]);
 		}
 	};
 
@@ -56,15 +46,7 @@ const IssueCategoryModal = ({ category, data }) => {
 			setLabelCategory(newLabelCategory);
 		}
 		if (labelCategory.every(x => x.id !== targetId)) {
-			setLabelCategory([
-				...labelCategory,
-				{
-					id: targetData.id,
-					name: targetData.name,
-					textColor: targetData.colors.textColor,
-					backgroundColor: targetData.colors.backgroundColor,
-				},
-			]);
+			setLabelCategory([...labelCategory, targetData]);
 		}
 	};
 
@@ -79,11 +61,7 @@ const IssueCategoryModal = ({ category, data }) => {
 			setMilestoneCategory(newMilestoneCategory);
 		}
 		if (milestoneCategory.id !== targetId) {
-			setMilestoneCategory({
-				id: targetData.id,
-				title: targetData.title,
-				dueDate: targetData.dueDate,
-			});
+			setMilestoneCategory(targetData);
 		}
 	};
 	//------------------------여기까지 중복 코드--------------

--- a/frontend/src/components/common/IssueCategory/IssueCategoryModal.jsx
+++ b/frontend/src/components/common/IssueCategory/IssueCategoryModal.jsx
@@ -13,6 +13,7 @@ import { useRecoilState, useResetRecoilState } from "recoil";
 import fetchData from "util/fetchData";
 import API from "util/API";
 const IssueCategoryModal = ({ category, data }) => {
+	//이 아래 3 상태 다른 페이지 넘어갈때 리셋되게 해야함(메인,편집,새 이슈)
 	const [assigneeCategory, setAssigneeCategory] = useRecoilState(
 		assigneeCategoryState
 	);
@@ -66,19 +67,6 @@ const IssueCategoryModal = ({ category, data }) => {
 			]);
 		}
 	};
-	// [	{
-	// 	id: targetData.id,
-	// 	name: targetData.name,
-	// 	textColor: targetData.colors.textColor,
-	// 	backgroundColor: targetData.colors.backgroundColor,
-	// },	{
-	// 	id: targetData.id,
-	// 	name: targetData.name,
-	// 	textColor: targetData.colors.textColor,
-	// 	backgroundColor: targetData.colors.backgroundColor,
-	// },].map(x => x.id)
-
-	// [id,id]
 
 	const handleCheckMilestone = e => {
 		const targetId = e.target.value;

--- a/frontend/src/components/common/IssueCategory/Label.jsx
+++ b/frontend/src/components/common/IssueCategory/Label.jsx
@@ -4,6 +4,7 @@ import { labelCategoryState } from "RecoilStore/Atoms";
 import { useRecoilValue } from "recoil";
 const Label = () => {
 	const labelData = useRecoilValue(labelCategoryState);
+
 	return (
 		<>
 			{labelData &&
@@ -11,8 +12,8 @@ const Label = () => {
 					<ContentsContainer key={`label-${idx}`}>
 						<LabelBadge
 							text={label.name}
-							fontColor={label.textColor}
-							backgroundColor={label.backgroundColor}
+							fontColor={label.colors?.textColor}
+							backgroundColor={label.colors?.backgroundColor}
 						/>
 					</ContentsContainer>
 				))}

--- a/frontend/src/components/pages/IssueDetailPage.jsx
+++ b/frontend/src/components/pages/IssueDetailPage.jsx
@@ -4,8 +4,13 @@ import IssueDetailHeader from "components/IssueDetail/IssueDetailHeader";
 import IssueDetailComments from "components/IssueDetail/IssueDetailComments";
 import IssueCategoryList from "components/common/IssueCategory/IssueCategoryList";
 import { useParams } from "react-router";
-import { useRecoilState } from "recoil";
-import { issueDetailUpdateState } from "RecoilStore/Atoms";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import {
+	issueDetailUpdateState,
+	assigneeCategoryState,
+	labelCategoryState,
+	milestoneCategoryState,
+} from "RecoilStore/Atoms";
 import fetchData from "util/fetchData";
 import API from "util/API";
 
@@ -13,9 +18,17 @@ const IssueDetailPage = () => {
 	const issueId = useParams().id;
 	const [issueData, setIssueData] = useState();
 	const [update, forceUpdate] = useRecoilState(issueDetailUpdateState);
+	const setAssigneeData = useSetRecoilState(assigneeCategoryState);
+	const setLabelData = useSetRecoilState(labelCategoryState);
+	const setMilestoneData = useSetRecoilState(milestoneCategoryState);
+
 	const getIssueData = async () => {
-		const data = await fetchData(API.issue(issueId), "GET");
-		setIssueData(data.issue);
+		const { issue } = await fetchData(API.issue(issueId), "GET");
+		const { assignees, labels, milestone } = issue;
+		setIssueData(issue);
+		setAssigneeData(assignees);
+		setLabelData(labels);
+		setMilestoneData(milestone);
 	};
 
 	useEffect(() => {
@@ -29,7 +42,7 @@ const IssueDetailPage = () => {
 					<IssueDetailHeader issueData={issueData} />
 					<ContentsWrapper>
 						<IssueDetailComments issueData={issueData} />
-						<IssueCategoryList issueData={issueData} />
+						<IssueCategoryList />
 					</ContentsWrapper>
 				</IssueWrapper>
 			)}


### PR DESCRIPTION
구디~~~~~~진행 상황 공유 드려요!
이슈 디테일에서 이슈 카테고리 부분은 작동은 하는데 수정한 내용으로 반영 아직 안 되는 상태입니다~~
 
<진행사항>
- [x]  header의 logo 누르면 category 리셋 되도록 구현 
- [x] issue detail page 내 issue category rendering
- [x] main page 필터 모달창, 버튼 버그 해결 (지난 pr에서 이미 반영됨!)

<구현 중>
- [ ] 카테고리 편집 
- [ ] 카테고리 모달 열 때 이미 선택된 카테고리 값에 checked 되도록 하기