### PR TITLE
[FE] 새 코멘트 등록시 not function 에러 뜨는 것 해결

### DIFF
--- a/frontend/src/components/common/CommentInput.jsx
+++ b/frontend/src/components/common/CommentInput.jsx
@@ -52,7 +52,7 @@ const CommentInput = ({
 			issueId,
 			content: "",
 		});
-		setCommentEditMode(false);
+		setCommentEditMode && setCommentEditMode(false);
 		forceUpdate(!update);
 	};
 


### PR DESCRIPTION
* 코멘트를 입력하고 추가하는 CommentInput 컴포넌트에서 코멘트 수정과 등록을 함께 도맡아서 하는 submitComment 라는 함수가 있습니다.
* 이 함수 안에서 코멘트 수정 로직과 코멘트 등록 로직이 함께 들어있어 참조 오류가 발생했었습니다.
*commentEditMode를 set 하는 setCommentEditMode 함수 본인이 컴포넌트에 존재할 때만 실행되도록 수정했습니다.  