### PR TITLE
[FE] 초기 메인 페이지 진입시 열린 이슈만 렌더링 

### DIFF
--- a/frontend/src/components/Issues/IssueList/IssueList.jsx
+++ b/frontend/src/components/Issues/IssueList/IssueList.jsx
@@ -7,7 +7,7 @@ import { selectedCardsState, issueListUpdateState } from "RecoilStore/Atoms";
 import API from "util/API";
 import fetchData from "util/fetchData";
 
-const IssueList = () => {
+const IssueList = ({ filter }) => {
 	const [isAnyIssueSelected, setIsAnyIssueSelected] = useState(false); // 상태 위치 협의 후 수정
 	const [isAllIssueSelected, setIsAllIssueSelected] = useState(false);
 	const [selectedCards, setSelectedCards] = useRecoilState(selectedCardsState);
@@ -17,35 +17,39 @@ const IssueList = () => {
 		const { issues } = await fetchData(API.issues(), "GET");
 		setIssues(issues);
 	};
-
+	console.log("issuesData: ", issuesData);
+	console.log("filter: ", filter);
 	useEffect(() => {
 		fetchIssueData();
 	}, [update]);
 
-	const issueList = issuesData?.map(issue => (
-		<IssueCard
-			key={issue.id}
-			issue={issue}
-			setIsAnyIssueSelected={setIsAnyIssueSelected}
-			isAllIssueSelected={isAllIssueSelected}
-			setIsAllIssueSelected={setIsAllIssueSelected}
-		/>
-	));
+	const filteredIssueList = issuesData
+		?.filter(issue => issue.open)
+		.map(issue => (
+			<IssueCard
+				key={issue.id}
+				issue={issue}
+				setIsAnyIssueSelected={setIsAnyIssueSelected}
+				isAllIssueSelected={isAllIssueSelected}
+				setIsAllIssueSelected={setIsAllIssueSelected}
+			/>
+		));
 
 	return (
 		<>
-			{issuesData && (
+			{filteredIssueList && (
 				<StyledIssueList>
 					<IssuesHeader
-						issuesCnt={issuesData.length}
+						filteredIssueList={filteredIssueList}
+						issuesData={issuesData}
 						isAnyIssueSelected={isAnyIssueSelected}
 						setIsAnyIssueSelected={setIsAnyIssueSelected}
 						isAllIssueSelected={isAllIssueSelected}
 						setIsAllIssueSelected={setIsAllIssueSelected}
 						selectedCards={selectedCards}
 					/>
-					{issueList.length ? (
-						issueList
+					{filteredIssueList.length ? (
+						filteredIssueList
 					) : (
 						<ErrorCard>검색과 일치하는 결과가 없습니다</ErrorCard>
 					)}

--- a/frontend/src/components/Issues/IssueList/IssueList.jsx
+++ b/frontend/src/components/Issues/IssueList/IssueList.jsx
@@ -24,7 +24,7 @@ const IssueList = ({ filter }) => {
 	}, [update]);
 
 	const filteredIssueList = issuesData
-		?.filter(issue => issue.open)
+		?.filter(issue => issue.open) // 메인화면 띄워줄 이슈 필터링(0712)
 		.map(issue => (
 			<IssueCard
 				key={issue.id}

--- a/frontend/src/components/Issues/IssueList/IssuesHeader.jsx
+++ b/frontend/src/components/Issues/IssueList/IssuesHeader.jsx
@@ -13,7 +13,8 @@ import {
 } from "RecoilStore/Atoms";
 
 const IssuesHeader = ({
-	issuesCnt,
+	issuesData,
+	filteredIssueList,
 	isAnyIssueSelected,
 	setIsAnyIssueSelected,
 	isAllIssueSelected,
@@ -24,6 +25,8 @@ const IssuesHeader = ({
 	);
 	const buttonNames = ["담당자", "레이블", "마일스톤", "작성자"];
 	const setClickedFilterState = useSetRecoilState(clickedFilterState);
+	const openIssueCnt = issuesData.filter(issue => issue.open).length;
+	const closedIssueCnt = issuesData.filter(issue => !issue.open).length;
 
 	//----------중복 코드from MeuFilter --------
 	const [isFilterClicked, setIsFilterClicked] =
@@ -57,7 +60,9 @@ const IssuesHeader = ({
 
 	const checkAllIssue = () => {
 		setIsAllIssueSelected(!isAllIssueSelected);
-		isAllIssueSelected ? setSelectedIssues(0) : setSelectedIssues(issuesCnt);
+		isAllIssueSelected
+			? setSelectedIssues(0)
+			: setSelectedIssues(filteredIssueList.length);
 	};
 
 	useEffect(() => {
@@ -75,10 +80,12 @@ const IssuesHeader = ({
 			) : (
 				<FilterOpenClose>
 					<TextIconDivider>
-						<Alert stroke={theme.grayScale.title_active} /> 열린 이슈(n)
+						<Alert stroke={theme.grayScale.title_active} /> 열린 이슈(
+						{openIssueCnt})
 					</TextIconDivider>
 					<TextIconDivider>
-						<Archive stroke={theme.grayScale.label} /> 닫힌 이슈(n)
+						<Archive stroke={theme.grayScale.label} /> 닫힌 이슈(
+						{closedIssueCnt})
 					</TextIconDivider>
 				</FilterOpenClose>
 			)}

--- a/frontend/src/components/Issues/Issues.jsx
+++ b/frontend/src/components/Issues/Issues.jsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 import IssueList from "./IssueList/IssueList";
 import Menu from "./Menu/Menu";
-const Issues = () => {
+const Issues = ({ filter }) => {
 	return (
 		<StyledIssues>
 			<Menu />
-			<IssueList />
+			<IssueList filter={filter} />
 		</StyledIssues>
 	);
 };

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -14,7 +14,7 @@ const Header = () => {
 
 	return (
 		<StyleHeader onClick={handleClick}>
-			<Link to="/main">
+			<Link to="/main?open=true">
 				<Logo />
 			</Link>
 			<ImgWrapper>

--- a/frontend/src/components/common/IssueCategory/IssueCategoryModal.jsx
+++ b/frontend/src/components/common/IssueCategory/IssueCategoryModal.jsx
@@ -78,14 +78,19 @@ const IssueCategoryModal = ({ category, data }) => {
 					await fetchData(API.issueAssigneesPOST(issueId), "POST", {
 						assigneeId: targetId,
 					});
+					break;
 				case CATEGORY_ENG.LABEL:
 					await fetchData(API.issueLabelsPOST(issueId), "POST", {
 						labelId: targetId,
 					});
+					break;
 				case CATEGORY_ENG.MILESTONE:
 					await fetchData(API.issueMilestone(issueId), "POST", {
 						milestoneId: targetId,
 					});
+					break;
+				default:
+					throw new Error("unhandled category");
 			}
 		} else {
 			switch (category) {
@@ -94,10 +99,15 @@ const IssueCategoryModal = ({ category, data }) => {
 						API.issueAssigneesDELETE(issueId, targetId),
 						"DELETE"
 					);
+					break;
 				case CATEGORY_ENG.LABEL:
 					await fetchData(API.issueLabelsDELETE(issueId, targetId), "DELETE");
+					break;
 				case CATEGORY_ENG.MILESTONE:
 					await fetchData(API.issueMilestone(issueId), "DELETE");
+					break;
+				default:
+					throw new Error("unhandled category");
 			}
 		}
 	};

--- a/frontend/src/components/pages/IssueDetailPage.jsx
+++ b/frontend/src/components/pages/IssueDetailPage.jsx
@@ -17,7 +17,8 @@ import API from "util/API";
 
 const IssueDetailPage = props => {
 	console.log("props:", props);
-	const issueId = useParams().id;
+	const params = useParams();
+	const issueId = params.id;
 	const setCurrentIssueId = useSetRecoilState(currentIssueId);
 	const [issueData, setIssueData] = useState();
 	const [isTitleEditMode, setIsTitleEditMode] = useState(false);

--- a/frontend/src/components/pages/IssueDetailPage.jsx
+++ b/frontend/src/components/pages/IssueDetailPage.jsx
@@ -15,7 +15,8 @@ import {
 import fetchData from "util/fetchData";
 import API from "util/API";
 
-const IssueDetailPage = () => {
+const IssueDetailPage = props => {
+	console.log("props:", props);
 	const issueId = useParams().id;
 	const setCurrentIssueId = useSetRecoilState(currentIssueId);
 	const [issueData, setIssueData] = useState();

--- a/frontend/src/components/pages/LoginLoadingPage.jsx
+++ b/frontend/src/components/pages/LoginLoadingPage.jsx
@@ -19,7 +19,7 @@ const LoginLoadingPage = () => {
 		getToken();
 	}, []);
 
-	return <>{isLogin ? <Redirect to="/main" /> : <>Loading..</>}</>;
+	return <>{isLogin ? <Redirect to="/main?open=true" /> : <>Loading..</>}</>;
 };
 
 export default LoginLoadingPage;

--- a/frontend/src/components/pages/MainPage.jsx
+++ b/frontend/src/components/pages/MainPage.jsx
@@ -11,8 +11,8 @@ import Issues from "components/Issues/Issues";
 import qsParser from "util/qsParser";
 
 const MainPage = ({ location }) => {
-	const parsed = qsParser(location.search);
-	console.log(parsed);
+	const filter = qsParser(location.search);
+	console.log(filter);
 	const { pathname } = window.location;
 	return localStorage.getItem("accessToken") ? (
 		<MainPageLayout>
@@ -20,7 +20,7 @@ const MainPage = ({ location }) => {
 			{(pathname === "/main/labels" || pathname === "/main/milestones") && (
 				<Navigator />
 			)}
-			{pathname === "/main" && <Issues />}
+			{pathname === "/main" && <Issues filter={filter} />}
 			<Switch>
 				<Route exact path="/main/milestones" component={MilestonesPage} />
 				<Route exact path="/main/labels" component={LabelsPage} />

--- a/frontend/src/components/pages/MainPage.jsx
+++ b/frontend/src/components/pages/MainPage.jsx
@@ -8,8 +8,11 @@ import MilestonesPage from "./MilestonesPage";
 import Header from "components/common/Header";
 import Navigator from "components/common/Navigator";
 import Issues from "components/Issues/Issues";
+import qsParser from "util/qsParser";
 
-const MainPage = () => {
+const MainPage = ({ location }) => {
+	const parsed = qsParser(location.search);
+	console.log(parsed);
 	const { pathname } = window.location;
 	return localStorage.getItem("accessToken") ? (
 		<MainPageLayout>

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -1,24 +1,3 @@
-export const issues = [
-	{
-		title: "issue-list 만들기",
-		id: 1,
-		labelId: 2,
-		milestoneId: 4,
-		author: "goody",
-		createdAt: "2021-06-10T23:50:14",
-		isOpen: true,
-	},
-	{
-		title: "mainPage에 menu 만들기",
-		id: 2,
-		labelId: 2,
-		milestoneId: 4,
-		author: "daisy",
-		createdAt: "2021-06-14T15:00:00",
-		isOpen: false,
-	},
-];
-
 export const filterData = {
 	issue: [
 		"열린 이슈",

--- a/frontend/src/hooks/useDebounce.jsx
+++ b/frontend/src/hooks/useDebounce.jsx
@@ -4,7 +4,6 @@ const useDebounce = (value, timeout) => {
 
 	useEffect(() => {
 		const handler = setTimeout(() => setState(value), timeout);
-
 		return () => clearTimeout(handler);
 	}, [value, timeout]);
 

--- a/frontend/src/util/qsParser.js
+++ b/frontend/src/util/qsParser.js
@@ -1,0 +1,14 @@
+const qsParser = url => {
+	return url.split("&").map(str => {
+		if (str[0] === "?") {
+			let d = "";
+			for (let i = 1; i < str.length; i++) {
+				d += str[i];
+			}
+			return d.split("=");
+		}
+		return str.split("=");
+	});
+};
+
+export default qsParser;


### PR DESCRIPTION
# 작업내용

* 메인 페이지 첫 진입시에 열린 이슈만 보이도록 설정하기 위해서 메인페이지 url을 `localhost:3000/main/` 에서 `localhost:3000/main?open=true` 로 바꿔두었습니다.
* 메인 페이지에서 열린 이슈의 개수와 닫힌 이슈의 개수를 볼 수 있습니다.