### PR TITLE
[FE] filter modal 값 선택에 따른 라우팅 처리 (진행중)

### DIFF
--- a/frontend/src/components/Issues/IssueList/IssueCard.jsx
+++ b/frontend/src/components/Issues/IssueList/IssueCard.jsx
@@ -23,8 +23,16 @@ const IssueCard = ({
 	);
 	const [selectedCards, setSelectedCards] = useRecoilState(selectedCardsState);
 
-	const { title, id, labels, milestone, author, createdAt, open, assignees } =
-		issue;
+	const {
+		title,
+		id,
+		labels,
+		milestone,
+		author,
+		createdAt,
+		open,
+		assignees,
+	} = issue;
 
 	const handleCheck = () => {
 		setIsChecked(!isChecked);
@@ -76,7 +84,7 @@ const IssueCard = ({
 						<LabelContainer>
 							{labels.length > 0
 								? labels.map((label, idx) => (
-										<Margin>
+										<Margin key={idx}>
 											<LabelBadge
 												key={label.id}
 												text={label.name}

--- a/frontend/src/components/Issues/IssueList/IssueList.jsx
+++ b/frontend/src/components/Issues/IssueList/IssueList.jsx
@@ -17,8 +17,7 @@ const IssueList = ({ filter }) => {
 		const { issues } = await fetchData(API.issues(), "GET");
 		setIssues(issues);
 	};
-	console.log("issuesData: ", issuesData);
-	console.log("filter: ", filter);
+
 	useEffect(() => {
 		fetchIssueData();
 	}, [update]);

--- a/frontend/src/components/Issues/IssueList/IssuesHeader.jsx
+++ b/frontend/src/components/Issues/IssueList/IssuesHeader.jsx
@@ -29,8 +29,9 @@ const IssuesHeader = ({
 	const closedIssueCnt = issuesData.filter(issue => !issue.open).length;
 
 	//----------중복 코드from MeuFilter --------
-	const [isFilterClicked, setIsFilterClicked] =
-		useRecoilState(filterClickFlagState);
+	const [isFilterClicked, setIsFilterClicked] = useRecoilState(
+		filterClickFlagState
+	);
 
 	const handleClick = useCallback(e => {
 		isFilterClicked === false
@@ -91,19 +92,20 @@ const IssuesHeader = ({
 			)}
 			<FilterMain>
 				{isAnyIssueSelected ? (
-					<ButtonContainer>
+					<ButtonContainer key={"filter-0"}>
 						<DropDownButton
 							text="상태 수정"
 							clickEvent={handleClick}
 							className={"issue-header-button"}
 							width={({ theme }) => theme.buttonWidths.lg}
 							border={"none"}
+							key={"filter-0"}
 						></DropDownButton>
 					</ButtonContainer>
 				) : (
 					<FiltersWrapper>
 						{buttonNames.map((filter, idx) => (
-							<ButtonContainer>
+							<ButtonContainer key={`filter-${idx + 1}`}>
 								<DropDownButton
 									text={filter}
 									clickEvent={handleClick}
@@ -111,7 +113,7 @@ const IssuesHeader = ({
 									className={"issue-header-button"}
 									width={({ theme }) => theme.buttonWidths.small}
 									border={"none"}
-								></DropDownButton>
+								/>
 							</ButtonContainer>
 						))}
 					</FiltersWrapper>

--- a/frontend/src/components/Issues/Menu/MenuFilterBar.jsx
+++ b/frontend/src/components/Issues/Menu/MenuFilterBar.jsx
@@ -10,27 +10,27 @@ import {
 } from "RecoilStore/Atoms";
 import { useSetRecoilState, useRecoilValue, useRecoilState } from "recoil";
 const MenuFilterBar = () => {
-	const [isFilterClicked, setIsFilterClicked] =
-		useRecoilState(filterClickFlagState);
+	const [isFilterClicked, setIsFilterClicked] = useRecoilState(
+		filterClickFlagState
+	);
 	const setClickedFilterState = useSetRecoilState(clickedFilterState);
 	const filterBarInput = useRecoilValue(filterBarInputState);
-
+	console.log(filterBarInput);
 	const getFilterBarString = () => {
-		return Object.entries(filterBarInput).reduce((acc, item) => {
-			if (item[1]) {
-				if (item[0] === "placeholder") acc += `${item[1]} `;
-				else if (item[0] !== "openClose") acc += `${item[0]}:${item[1]} `;
+		return Object.entries(filterBarInput).reduce((acc, [key, value]) => {
+			if (value) {
+				if (key === "placeholder") acc += `${value} `;
+				else if (key !== "openClose") acc += `${key}:${value} `;
 			}
 			return acc;
 		}, "");
 	};
 
-	const handleClick = (e) => {
+	const handleClick = e => {
 		isFilterClicked === false
 			? setIsFilterClicked(true)
 			: setIsFilterClicked(false);
 		setClickedFilterState(e.currentTarget.value);
-		console.log(e.currentTarget.value);
 	};
 
 	useEffect(() => {
@@ -40,7 +40,7 @@ const MenuFilterBar = () => {
 		};
 	}, [isFilterClicked]);
 
-	const closeFilterModal = (e) => {
+	const closeFilterModal = e => {
 		const target = e.target;
 		if (isFilterClicked && !target.closest(".filter-modal"))
 			setIsFilterClicked(false);

--- a/frontend/src/components/Issues/Menu/MenuTab.jsx
+++ b/frontend/src/components/Issues/Menu/MenuTab.jsx
@@ -26,7 +26,7 @@ const MenuTab = () => {
 				labelCount={0}
 				milestoneClickEvent={handleMilestoneClick}
 				labelClickEvent={handleLabelClick}
-				isMainPage={true}
+				ismainpage="true"
 			/>
 			<Link to="main/new">
 				<AddButton text={"이슈 작성"} icon={"plus"} size={"m"} />

--- a/frontend/src/components/common/Button/BlueButtons.jsx
+++ b/frontend/src/components/common/Button/BlueButtons.jsx
@@ -1,4 +1,3 @@
-import Button from "@material-ui/core/Button";
 import { ReactComponent as EditIcon } from "images/edit.svg";
 import { ReactComponent as PlusIcon } from "images/plus.svg";
 import styled from "styled-components";
@@ -44,7 +43,10 @@ const BlueButtons = ({ text, icon, size, clickHandler }) => {
 	);
 };
 
-const BlueButton = styled(Button)`
+const BlueButton = styled.button`
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: ${props => props._width};
 	height: ${({ theme }) => theme.buttonHeights.base};
 	font-size: ${({ theme }) => theme.fontSizes.xs};

--- a/frontend/src/components/common/Button/ButtonGroup.jsx
+++ b/frontend/src/components/common/Button/ButtonGroup.jsx
@@ -15,7 +15,7 @@ const ButtonGroup = ({
 	milestoneClickEvent,
 	labelCount,
 	labelClickEvent,
-	isMainPage,
+	ismainpage,
 }) => {
 	const milestoneFlag = useRecoilValue(milestoneButtonFlagState);
 	const labelFlag = useRecoilValue(labelButtonFlagState);
@@ -28,7 +28,7 @@ const ButtonGroup = ({
 					_width={({ theme }) => theme.buttonWidths.base}
 					_radius={"left"}
 					bgColor={labelFlag}
-					isMainPage={isMainPage}
+					ismainpage={ismainpage}
 				>
 					<LabelIcon stroke={theme.grayScale.label} />
 					<ButtonText>레이블 ({labelCount})</ButtonText>
@@ -40,7 +40,7 @@ const ButtonGroup = ({
 					_width={({ theme }) => theme.buttonWidths.base}
 					_radius={"right"}
 					bgColor={milestoneFlag}
-					isMainPage={isMainPage}
+					ismainpage={ismainpage}
 				>
 					<MileStoneIcon fill={theme.grayScale.label} />
 					<ButtonText>마일스톤 ({milestoneCount})</ButtonText>

--- a/frontend/src/components/common/Button/WhiteButtons.jsx
+++ b/frontend/src/components/common/Button/WhiteButtons.jsx
@@ -1,4 +1,3 @@
-import Button from "@material-ui/core/Button";
 import { ReactComponent as XIcon } from "images/x-square.svg";
 import { ReactComponent as EditIcon } from "images/edit.svg";
 import { ReactComponent as PaperIcon } from "images/paperclip.svg";
@@ -52,7 +51,10 @@ const WhiteButtons = ({ text, icon, size, clickHandler }) => {
 	);
 };
 
-const WhiteButton = styled(Button)`
+const WhiteButton = styled.button`
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: ${props => props._width};
 	height: ${({ theme }) => theme.buttonHeights.base};
 	font-size: ${({ theme }) => theme.fontSizes.xs};

--- a/frontend/src/components/common/FilterModal.jsx
+++ b/frontend/src/components/common/FilterModal.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import {
 	filterBarInputState,
@@ -16,19 +17,22 @@ import FormControl from "@material-ui/core/FormControl";
 import FormLabel from "@material-ui/core/FormLabel";
 import API from "util/API";
 import fetchData from "util/fetchData";
-
+import getQueryString from "util/getQueryString";
 const FilterModal = () => {
 	const [clickedFilter, setClickedFilterState] = useState("");
 	const filterType = useRecoilValue(clickedFilterState);
-	const [filterBarInput, setFilterBarInputState] =
-		useRecoilState(filterBarInputState);
+	const [filterBarInput, setFilterBarInputState] = useRecoilState(
+		filterBarInputState
+	);
 	const [selectedCards, setSelectedCards] = useRecoilState(selectedCardsState);
 	const forceUpdate = useSetRecoilState(issueListUpdateState);
-
+	const [queryString, setQueryString] = useState("");
+	//console.log("filterBarInput,", filterBarInput);
 	const handleChange = event => {
 		setClickedFilterState(event.target.value);
 		setFilterStateByType(event.target.value);
 		onFilterValueClicked(event.target.value);
+		setQueryString(getQueryString(filterBarInput));
 	};
 
 	const onFilterValueClicked = value => {
@@ -136,16 +140,19 @@ const FilterModal = () => {
 					value={clickedFilter}
 					onClick={handleChange}
 				>
+					{/* 여기바꾸면 됨 */}
 					{list.length &&
 						list.map((text, idx) => (
-							<FilterControlLabel
-								value={text}
-								control={<Radio color="default" />}
-								label={text}
-								labelPlacement="start"
-								key={`filter-control-label-${idx}`}
-								checked={filterBarInput[`${getEngKey(filterType)}`] === text}
-							/>
+							<Link to={`/main?${queryString}`}>
+								<FilterControlLabel
+									value={text}
+									control={<Radio color="default" />}
+									label={text}
+									labelPlacement="start"
+									key={`filter-control-label-${idx}`}
+									checked={filterBarInput[`${getEngKey(filterType)}`] === text}
+								/>
+							</Link>
 						))}
 				</RadioGroup>
 			</FormControl>

--- a/frontend/src/components/common/Navigator.jsx
+++ b/frontend/src/components/common/Navigator.jsx
@@ -62,7 +62,7 @@ const Navigator = () => {
 				milestoneClickEvent={handleMilestoneClick}
 				labelCount={labelCount}
 				labelClickEvent={handleLabelClick}
-				isMainPage={false}
+				ismainpage="false"
 			/>
 
 			{addButtonFlag ? (

--- a/frontend/src/components/pages/MainPage.jsx
+++ b/frontend/src/components/pages/MainPage.jsx
@@ -12,7 +12,7 @@ import qsParser from "util/qsParser";
 
 const MainPage = ({ location }) => {
 	const filter = qsParser(location.search);
-	console.log(filter);
+	// console.log(filter);
 	const { pathname } = window.location;
 	return localStorage.getItem("accessToken") ? (
 		<MainPageLayout>

--- a/frontend/src/styles/StyledButtons.jsx
+++ b/frontend/src/styles/StyledButtons.jsx
@@ -1,7 +1,10 @@
 import styled from "styled-components";
 import Button from "@material-ui/core/Button";
 
-export const TabButton = styled(Button)`
+export const TabButton = styled.button`
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: ${props => props._width};
 	height: ${({ theme }) => theme.buttonHeights.base};
 	font-size: ${({ theme }) => theme.fontSizes.xs};

--- a/frontend/src/util/getQueryString.js
+++ b/frontend/src/util/getQueryString.js
@@ -1,0 +1,16 @@
+const getQueryString = queryState => {
+	//한 단계 늦게되네 왜그러징
+
+	const selectedFilters = Object.entries(queryState).filter(
+		x => x[0] !== "placeholder" && x[1] !== null
+	);
+
+	return selectedFilters.reduce((acc, [key, value], idx) => {
+		idx === selectedFilters.length - 1
+			? (acc += `${key}=${value}`)
+			: (acc += `${key}=${value}&`);
+		return acc;
+	}, "");
+};
+
+export default getQueryString;


### PR DESCRIPTION
- getQueryString 함수로 필터 객체를 받아서 쿼리스트링을 리턴하여 사용합니다.
- 필터 값 선택 (라디오 버튼 선택)에 따른 라우팅처리가 필요하여 일단 라디오 버튼 쪽을 Link로 감싸서 라우팅 한 상태입니다.
- 해결중인 오류 
- 1. 선택된 필터 값이 쿼리스트링에 늦게 반영됨 
- 2. A필터 클릭 후 B필터 클릭시 쿼리스트링에 바로 반영되지 않고 한번 지워졌다가 다른 필터를 또 눌렀을 때 반영됨, 컴포넌트 렌더랑 setState하는 시간차에서 발생하는 문제인거 같습니다.