### PR TITLE
[FE] 필터 모달 라디오 선택 값이 쿼리스트링에 한박자 늦게 반영되는 버그 수정 

### DIFF
--- a/frontend/src/RecoilStore/Atoms.jsx
+++ b/frontend/src/RecoilStore/Atoms.jsx
@@ -159,6 +159,11 @@ export const currentIssueId = atom({
 	default: null,
 });
 
+export const queryStringState = atom({
+	key: "queryStringState",
+	default: null,
+});
+
 //아래는 데이지 삽질 망한 결과입니다.---나중에 꼭 뜯어보리라..
 // export const categorySelector = selector({
 // 	key: "categorySelector",

--- a/frontend/src/components/common/FilterModal.jsx
+++ b/frontend/src/components/common/FilterModal.jsx
@@ -1,10 +1,10 @@
-import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import {
 	filterBarInputState,
 	clickedFilterState,
 	selectedCardsState,
 	issueListUpdateState,
+	queryStringState,
 } from "RecoilStore/Atoms";
 import { useRecoilValue, useRecoilState, useSetRecoilState } from "recoil";
 import { filterData, CATEGORY_KOR } from "data";
@@ -21,18 +21,15 @@ import getQueryString from "util/getQueryString";
 const FilterModal = () => {
 	const [clickedFilter, setClickedFilterState] = useState("");
 	const filterType = useRecoilValue(clickedFilterState);
-	const [filterBarInput, setFilterBarInputState] = useRecoilState(
-		filterBarInputState
-	);
+	const [filterBarInput, setFilterBarInputState] =
+		useRecoilState(filterBarInputState);
 	const [selectedCards, setSelectedCards] = useRecoilState(selectedCardsState);
 	const forceUpdate = useSetRecoilState(issueListUpdateState);
-	const [queryString, setQueryString] = useState("");
-	//console.log("filterBarInput,", filterBarInput);
+	const [queryString, setQueryString] = useRecoilState(queryStringState);
 	const handleChange = event => {
 		setClickedFilterState(event.target.value);
 		setFilterStateByType(event.target.value);
 		onFilterValueClicked(event.target.value);
-		setQueryString(getQueryString(filterBarInput));
 	};
 
 	const onFilterValueClicked = value => {
@@ -125,6 +122,13 @@ const FilterModal = () => {
 		filterDataByType();
 	}, []);
 
+	useEffect(() => {
+		setQueryString(getQueryString(filterBarInput));
+	}, [filterBarInput]);
+
+	console.log("filterBarInput: ", filterBarInput);
+	console.log("qs: ", queryString);
+
 	return (
 		<FilterModalLayout
 			className="filter-modal"
@@ -143,16 +147,16 @@ const FilterModal = () => {
 					{/* 여기바꾸면 됨 */}
 					{list.length &&
 						list.map((text, idx) => (
-							<Link to={`/main?${queryString}`}>
-								<FilterControlLabel
-									value={text}
-									control={<Radio color="default" />}
-									label={text}
-									labelPlacement="start"
-									key={`filter-control-label-${idx}`}
-									checked={filterBarInput[`${getEngKey(filterType)}`] === text}
-								/>
-							</Link>
+							// <Link to={`/main?${queryString}`}>
+							<FilterControlLabel
+								value={text}
+								control={<Radio color="default" />}
+								label={text}
+								labelPlacement="start"
+								key={`filter-control-label-${idx}`}
+								checked={filterBarInput[`${getEngKey(filterType)}`] === text}
+							/>
+							// </Link>
 						))}
 				</RadioGroup>
 			</FormControl>

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -3,20 +3,27 @@ import { ReactComponent as Logo } from "images/LogotypeMedium.svg";
 import { Link } from "react-router-dom";
 import getUserInfo from "util/getUserInfo";
 import { categorySelectorState } from "RecoilStore/Atoms";
-import { useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { queryStringState } from "RecoilStore/Atoms";
 const Header = () => {
 	const userInfo = getUserInfo();
 	const resetCategoryValue = useSetRecoilState(categorySelectorState);
-
+	const queryString = useRecoilValue(queryStringState);
 	const handleClick = () => {
 		resetCategoryValue();
 	};
 
 	return (
 		<StyleHeader onClick={handleClick}>
-			<Link to="/main?open=true">
-				<Logo />
-			</Link>
+			{queryString ? (
+				<Link to={`/main?${queryString}`}>
+					<Logo />
+				</Link>
+			) : (
+				<Link to="/main">
+					<Logo />
+				</Link>
+			)}
 			<ImgWrapper>
 				<img src={userInfo.imageUrl} alt={userInfo.gitHubId} />
 			</ImgWrapper>

--- a/frontend/src/components/pages/LoginLoadingPage.jsx
+++ b/frontend/src/components/pages/LoginLoadingPage.jsx
@@ -19,7 +19,7 @@ const LoginLoadingPage = () => {
 		getToken();
 	}, []);
 
-	return <>{isLogin ? <Redirect to="/main?open=true" /> : <>Loading..</>}</>;
+	return <>{isLogin ? <Redirect to="/main" /> : <>Loading..</>}</>;
 };
 
 export default LoginLoadingPage;

--- a/frontend/src/components/pages/MainPage.jsx
+++ b/frontend/src/components/pages/MainPage.jsx
@@ -9,18 +9,28 @@ import Header from "components/common/Header";
 import Navigator from "components/common/Navigator";
 import Issues from "components/Issues/Issues";
 import qsParser from "util/qsParser";
+import { queryStringState } from "RecoilStore/Atoms";
+import { useRecoilValue } from "recoil";
 
 const MainPage = ({ location }) => {
 	const filter = qsParser(location.search);
-	// console.log(filter);
 	const { pathname } = window.location;
+	const queryString = useRecoilValue(queryStringState);
+
 	return localStorage.getItem("accessToken") ? (
 		<MainPageLayout>
 			<Header pathName={pathname} />
 			{(pathname === "/main/labels" || pathname === "/main/milestones") && (
 				<Navigator />
 			)}
-			{pathname === "/main" && <Issues filter={filter} />}
+			{queryString && pathname === `/main` ? (
+				<>
+					<Redirect to={`/main?${queryString}`}></Redirect>
+					<Issues filter={filter} />
+				</>
+			) : (
+				pathname === `/main` && <Issues filter={filter} />
+			)}
 			<Switch>
 				<Route exact path="/main/milestones" component={MilestonesPage} />
 				<Route exact path="/main/labels" component={LabelsPage} />


### PR DESCRIPTION
# 기능구현

* 현재 적용된 필터들을 한번에 클린업 해주는 버튼을 추가했습니다.

# 수정사항

* 필터 모달에서 라디오 항목을 선택했을 때 쿼리스트링을 바꾸는 게 아니라,
filterBarInput이 바뀌면 쿼리스트링이 바뀌게끔 useEffect로 상태 변경 순서를 정해줬습니다.

* 기존의 Link to 태그를 빼고 MainPage.jsx에서 queryString 상태를 읽고 Redirect to 되게끔 변경했습니다.
