### PR TITLE
[FE] Main page 레이블/마일스톤 갯수, 열린/닫힌 이슈, query string reset

### DIFF
--- a/frontend/src/RecoilStore/Atoms.jsx
+++ b/frontend/src/RecoilStore/Atoms.jsx
@@ -161,7 +161,7 @@ export const currentIssueId = atom({
 
 export const queryStringState = atom({
 	key: "queryStringState",
-	default: null,
+	default: "",
 });
 
 export const issuesDataState = atom({

--- a/frontend/src/RecoilStore/Atoms.jsx
+++ b/frontend/src/RecoilStore/Atoms.jsx
@@ -164,44 +164,12 @@ export const queryStringState = atom({
 	default: null,
 });
 
-//아래는 데이지 삽질 망한 결과입니다.---나중에 꼭 뜯어보리라..
-// export const categorySelector = selector({
-// 	key: "categorySelector",
-// 	get: ({ get }) => {
-// 		const assignee = get(assigneeCategoryState);
-// 		const label = get(labelCategoryState);
-// 		const milestone = get(milestoneCategoryState);
-// 		return { assignee: assignee, label: label, milestone: milestone };
-// 	},
-// 	set: ({ set }, { category, payload }) => {
-// 		switch (category) {
-// 			case CATEGORY_ENG.ASSIGNEE:
-// 				set(assigneeCategoryState, prevState => [
-// 					...prevState,
-// 					{
-// 						id: payload.id,
-// 						githubId: payload.githubId,
-// 						imageUrl: payload.imageUrl,
-// 					},
-// 				]);
-// 			case CATEGORY_ENG.LABEL:
-// 				set(labelCategoryState, prevState => [
-// 					...prevState,
-// 					{
-// 						id: payload.id,
-// 						name: payload.name,
-// 						textColor: payload.colors.textColor,
-// 						backgroundColor: payload.colors.backgroundColor,
-// 					},
-// 				]);
-// 			case CATEGORY_ENG.MILESTONE:
-// 				set(milestoneCategoryState, prevState => [
-// 					{
-// 						id: payload.id,
-// 						title: payload.title,
-// 						dueDate: payload.dueDate,
-// 					},
-// 				]);
-// 		}
-// 	},
-// });
+export const issuesDataState = atom({
+	key: "issuesDataState",
+	default: null,
+});
+
+export const openIssueFlagState = atom({
+	key: "openIssueFlagState",
+	default: true,
+});

--- a/frontend/src/components/Issues/IssueList/IssueList.jsx
+++ b/frontend/src/components/Issues/IssueList/IssueList.jsx
@@ -3,7 +3,12 @@ import styled from "styled-components";
 import IssuesHeader from "./IssuesHeader";
 import IssueCard from "./IssueCard";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { selectedCardsState, issueListUpdateState } from "RecoilStore/Atoms";
+import {
+	selectedCardsState,
+	issueListUpdateState,
+	issuesDataState,
+	openIssueFlagState,
+} from "RecoilStore/Atoms";
 import API from "util/API";
 import fetchData from "util/fetchData";
 
@@ -11,9 +16,12 @@ const IssueList = ({ filter }) => {
 	const [isAnyIssueSelected, setIsAnyIssueSelected] = useState(false); // 상태 위치 협의 후 수정
 	const [isAllIssueSelected, setIsAllIssueSelected] = useState(false);
 	const [selectedCards, setSelectedCards] = useRecoilState(selectedCardsState);
-	const [issuesData, setIssues] = useState();
+	const [issuesData, setIssues] = useRecoilState(issuesDataState);
 	const update = useRecoilValue(issueListUpdateState);
+	const openIssueFlag = useRecoilValue(openIssueFlagState);
+
 	const fetchIssueData = async () => {
+		//필터 body에 붙이는 거 되면 querystring분석해서 body에 넣어 보내기
 		const { issues } = await fetchData(API.issues(), "GET");
 		setIssues(issues);
 	};
@@ -21,9 +29,9 @@ const IssueList = ({ filter }) => {
 	useEffect(() => {
 		fetchIssueData();
 	}, [update]);
-
+	// 메인화면 띄워줄 이슈 필터링(0712) find/include/indexOf/customHook
 	const filteredIssueList = issuesData
-		?.filter(issue => issue.open) // 메인화면 띄워줄 이슈 필터링(0712) find/include/indexOf/customHook
+		?.filter(issue => issue.open === openIssueFlag)
 		.map(issue => (
 			<IssueCard
 				key={issue.id}

--- a/frontend/src/components/Issues/IssueList/IssuesHeader.jsx
+++ b/frontend/src/components/Issues/IssueList/IssuesHeader.jsx
@@ -10,6 +10,7 @@ import {
 	selectedIssueCntState,
 	clickedFilterState,
 	filterClickFlagState,
+	openIssueFlagState,
 } from "RecoilStore/Atoms";
 
 const IssuesHeader = ({
@@ -28,7 +29,7 @@ const IssuesHeader = ({
 	const openIssueCnt = issuesData.filter(issue => issue.open).length;
 	const closedIssueCnt = issuesData.filter(issue => !issue.open).length;
 
-	//----------중복 코드from MeuFilter --------
+	//------------------
 	const [isFilterClicked, setIsFilterClicked] = useRecoilState(
 		filterClickFlagState
 	);
@@ -40,6 +41,7 @@ const IssuesHeader = ({
 
 		setClickedFilterState(e.currentTarget.value);
 	});
+	const setOpenIssueFlag = useSetRecoilState(openIssueFlagState);
 
 	useEffect(() => {
 		window.addEventListener("click", closeFilterModal);
@@ -57,7 +59,7 @@ const IssuesHeader = ({
 		)
 			setIsFilterClicked(false);
 	};
-	//----------여기 까지 중복 코드from MeuFilter --------/
+	//----------from MeuFilter --------/
 
 	const checkAllIssue = () => {
 		setIsAllIssueSelected(!isAllIssueSelected);
@@ -81,12 +83,18 @@ const IssuesHeader = ({
 			) : (
 				<FilterOpenClose>
 					<TextIconDivider>
-						<Alert stroke={theme.grayScale.title_active} /> 열린 이슈(
-						{openIssueCnt})
+						<Alert stroke={theme.grayScale.title_active} />
+						<Text onClick={() => setOpenIssueFlag(true)}>
+							열린 이슈(
+							{openIssueCnt})
+						</Text>
 					</TextIconDivider>
 					<TextIconDivider>
-						<Archive stroke={theme.grayScale.label} /> 닫힌 이슈(
-						{closedIssueCnt})
+						<Archive stroke={theme.grayScale.label} />
+						<Text onClick={() => setOpenIssueFlag(false)}>
+							닫힌 이슈(
+							{closedIssueCnt})
+						</Text>
 					</TextIconDivider>
 				</FilterOpenClose>
 			)}
@@ -147,7 +155,13 @@ const CheckBox = styled.div`
 `;
 
 const TextIconDivider = styled.div`
+	display: flex;
 	width: 100%;
+`;
+
+const Text = styled.div`
+	cursor: pointer;
+	padding-left: 10px;
 `;
 
 export default IssuesHeader;

--- a/frontend/src/components/Issues/Menu/Menu.jsx
+++ b/frontend/src/components/Issues/Menu/Menu.jsx
@@ -1,24 +1,37 @@
+import { useEffect } from "react";
+import { useResetRecoilState, useSetRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import MenuFilterBar from "./MenuFilterBar";
 import MenuTab from "./MenuTab";
-import { queryStringState, filterBarInputState } from "RecoilStore/Atoms";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import {
+	queryStringState,
+	filterBarInputState,
+	labelCountState,
+	milestoneCountState,
+} from "RecoilStore/Atoms";
+import API from "util/API";
+import fetchData from "util/fetchData";
 
 const Menu = () => {
-	const [queryString, setQueryString] = useRecoilState(queryStringState);
-	const setFilterBarInputState = useSetRecoilState(filterBarInputState);
-
+	const queryString = useRecoilValue(queryStringState);
+	const resetFilterBarInputState = useResetRecoilState(filterBarInputState);
+	const setLabelCount = useSetRecoilState(labelCountState);
+	const setMilestoneCount = useSetRecoilState(milestoneCountState);
+	const resetQueryStringState = useResetRecoilState(queryStringState);
 	const handleClick = () => {
-		setFilterBarInputState({
-			placeholder: "is:issue is:open",
-			assignee: null,
-			label: null,
-			milestone: null,
-			author: null,
-			issue: null,
-			openClose: null,
-		});
-		setQueryString(null);
+		resetFilterBarInputState();
+		resetQueryStringState();
+	};
+
+	useEffect(() => {
+		getLabelMilestoneData();
+	}, []);
+
+	const getLabelMilestoneData = async () => {
+		const { labels } = await fetchData(API.labels(), "GET");
+		const { milestones } = await fetchData(API.milestones(), "GET");
+		setLabelCount(labels.length);
+		setMilestoneCount(milestones.length);
 	};
 
 	return (

--- a/frontend/src/components/Issues/Menu/MenuFilterBar.jsx
+++ b/frontend/src/components/Issues/Menu/MenuFilterBar.jsx
@@ -15,7 +15,7 @@ const MenuFilterBar = () => {
 	);
 	const setClickedFilterState = useSetRecoilState(clickedFilterState);
 	const filterBarInput = useRecoilValue(filterBarInputState);
-	console.log(filterBarInput);
+
 	const getFilterBarString = () => {
 		return Object.entries(filterBarInput).reduce((acc, [key, value]) => {
 			if (value) {

--- a/frontend/src/components/Issues/Menu/MenuTab.jsx
+++ b/frontend/src/components/Issues/Menu/MenuTab.jsx
@@ -2,14 +2,18 @@ import styled from "styled-components";
 import ButtonGroup from "components/common/Button/ButtonGroup";
 import AddButton from "components/common/Button/BlueButtons";
 import { Link } from "react-router-dom";
-import { useSetRecoilState } from "recoil";
+import { useSetRecoilState, useRecoilValue } from "recoil";
 import {
 	labelButtonFlagState,
 	milestoneButtonFlagState,
+	labelCountState,
+	milestoneCountState,
 } from "RecoilStore/Atoms";
 const MenuTab = () => {
 	const setMilestoneFlag = useSetRecoilState(milestoneButtonFlagState);
 	const setLabelFlag = useSetRecoilState(labelButtonFlagState);
+	const labelCount = useRecoilValue(labelCountState);
+	const milestoneCount = useRecoilValue(milestoneCountState);
 
 	const handleMilestoneClick = () => {
 		setMilestoneFlag(true);
@@ -22,8 +26,8 @@ const MenuTab = () => {
 	return (
 		<Wrapper>
 			<ButtonGroup
-				milestoneCount={0}
-				labelCount={0}
+				milestoneCount={milestoneCount}
+				labelCount={labelCount}
 				milestoneClickEvent={handleMilestoneClick}
 				labelClickEvent={handleLabelClick}
 				ismainpage="true"

--- a/frontend/src/components/Labels/Labels.jsx
+++ b/frontend/src/components/Labels/Labels.jsx
@@ -36,7 +36,7 @@ const Labels = () => {
 
 	useEffect(() => {
 		getLabelData();
-	}, [forceUpdate]); //forceUpdate를 의존 배열에 넣음 대박!!
+	}, [forceUpdate]);
 
 	return (
 		<>

--- a/frontend/src/components/common/Navigator.jsx
+++ b/frontend/src/components/common/Navigator.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import ButtonGroup from "./Button/ButtonGroup";
 import AddButton from "./Button/BlueButtons";
 import CancelButton from "components/common/Button/WhiteButtons";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import {
 	labelButtonFlagState,
 	milestoneButtonFlagState,
@@ -11,18 +11,17 @@ import {
 	navigatorAddButtonFlagState,
 	labelCountState,
 } from "RecoilStore/Atoms";
-import { useState } from "react";
+
 import { milestoneCountState } from "RecoilStore/Atoms";
 
 const Navigator = () => {
-	// const [isAddButton, setIsAddButton] = useState(true);
 	const [addButtonFlag, setAddButtonFlag] = useRecoilState(
 		navigatorAddButtonFlagState
 	);
 	const [milestoneFlag, setMilestoneFlag] = useRecoilState(
 		milestoneButtonFlagState
 	);
-	const [labelFlag, setLabelFlag] = useRecoilState(labelButtonFlagState);
+	const setLabelFlag = useSetRecoilState(labelButtonFlagState);
 	const [milestoneAddBtnFlag, setMilestoneAddBtnFlag] = useRecoilState(
 		milestoneAddButtonFlagState
 	);
@@ -40,8 +39,7 @@ const Navigator = () => {
 		setMilestoneFlag(false);
 		setLabelFlag(true);
 	};
-	//Refactoring
-	//리렌더 2번 일어남
+
 	const handleClick = () => {
 		if (milestoneFlag) {
 			setMilestoneAddBtnFlag(!milestoneAddBtnFlag);
@@ -56,7 +54,6 @@ const Navigator = () => {
 
 	return (
 		<NavigatorLayout>
-			{/* 버튼 그룹 카운트 자리에 데이터 길이 넣어주기 */}
 			<ButtonGroup
 				milestoneCount={milestoneCountValue}
 				milestoneClickEvent={handleMilestoneClick}

--- a/frontend/src/components/pages/MainPage.jsx
+++ b/frontend/src/components/pages/MainPage.jsx
@@ -11,17 +11,11 @@ import Issues from "components/Issues/Issues";
 import qsParser from "util/qsParser";
 import { queryStringState } from "RecoilStore/Atoms";
 import { useRecoilValue } from "recoil";
-import { useEffect, useState } from "react";
 
 const MainPage = ({ location }) => {
 	const filter = qsParser(location.search);
 	const { pathname } = window.location;
 	const queryString = useRecoilValue(queryStringState);
-	const [update, setUpdate] = useState(false);
-
-	useEffect(() => {
-		setUpdate(x => !x);
-	}, [queryString]);
 
 	return localStorage.getItem("accessToken") ? (
 		<MainPageLayout>
@@ -29,13 +23,11 @@ const MainPage = ({ location }) => {
 			{(pathname === "/main/labels" || pathname === "/main/milestones") && (
 				<Navigator />
 			)}
-			{queryString && pathname === `/main` ? (
+			{pathname === `/main` && (
 				<>
 					<Redirect to={`/main?${queryString}`}></Redirect>
 					<Issues filter={filter} />
 				</>
-			) : (
-				pathname === `/main` && <Issues filter={filter} />
 			)}
 			<Switch>
 				<Route exact path="/main/milestones" component={MilestonesPage} />

--- a/frontend/src/util/fetchData.js
+++ b/frontend/src/util/fetchData.js
@@ -1,20 +1,33 @@
-const fetchData = async (url, method, reqData) => {
-	const option =
-		(method === "GET") | "DELETE"
-			? {
-					headers: {
-						"Content-Type": "application/json",
-						Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-					},
-			  }
-			: {
-					method: method,
-					headers: {
-						"Content-Type": "application/json",
-						Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-					},
-					body: JSON.stringify(reqData),
-			  };
+const fetchData = async (url, method, reqData = undefined) => {
+	let option;
+	if ((method === "GET") | (method === "DELETE")) {
+		if (reqData) {
+			option = {
+				method: method,
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+				},
+				body: JSON.stringify(reqData),
+			};
+		} else {
+			option = {
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+				},
+			};
+		}
+	} else {
+		option = {
+			method: method,
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+			},
+			body: JSON.stringify(reqData),
+		};
+	}
 
 	try {
 		console.log("reqData:", reqData);

--- a/frontend/src/util/getFilteredData.js
+++ b/frontend/src/util/getFilteredData.js
@@ -1,0 +1,46 @@
+const getFilteredData = (type, value, data) => {
+	if (type === "assignees") {
+		const result = data.forEach(x => {
+			const { assignees } = x;
+			console.log(assignees);
+			const assignee = assignees.forEach(x => {
+				if (x.githubId !== value) return false;
+				console.log(x.githubId);
+			});
+
+			const { githubId } = assignees;
+		});
+	}
+};
+
+export default getFilteredData;
+
+// [["assignee", "damilog"], ["milestone", "한라산 정상 찍기"]]
+// const getFilteredData = (filters, data) => {
+// 	if (!filters || !data) return;
+// 	console.log("filters", filters);
+// 	console.log("data", data);
+
+// 	return filters.reduce((res, filter) => {
+// 		const [type, payload] = filter;
+// 		console.log("res", res);
+// 		return res.filter(x => x[type] === payload);
+// 	}, data);
+// };
+
+// const result = data
+// 	.filterData("assignee", "damilog")
+// 	.filterData("label", "red");
+
+// const pipe = (...funcs) => v => {
+// 	return funcs.reduce((res, func) => {
+// 		return func(res);
+// 	}, v);
+// };
+
+// pipe(
+//   filter(u => u.age >= 18),
+//   map(u => u.name),
+// )(users) //["Jack", "Milady"]
+
+// pipe(mapWords, reduceWords)(['foo', 'bar', 'baz']);


### PR DESCRIPTION
진행 사항
이슈 필터 만들다 결국 포기하고 자잘한 기능 추가함 

- Main page 레이블, 마일스톤 갯수 렌더링 
- 열린/닫힌 이슈 버튼 클릭시 해당 필터링 된 이슈만 보여지게 끔 수정 
- query string reset이 되지 않는 오류 해결

-----
공유 사항
- issue filter API 사용하려 했는데 body 값을 어떻게 보내줘야 할 지 확실치 않아서 쿠퍼에게 질문 보냄(답변 기다리는중~~) 
```
wiki에는 GET 요청 body에 아래와 같이 보내는 걸로 적혀있는데, 만일 필터 1개만 적용하고 싶으면
   {
    "author" : UUID
    "assignee" : UUID
    "label" : String
    "milestone" : String
    "open" : Boolean
    "commentAuthor" : UUID
   }
아래 처럼 적용하고 싶은 필터만 body에적어서 보내면 되나요? 아니면
 {
    "open" : true
 }
아래 처럼 공백으로 보내야 하나요?
{
   author: "",
   assignee: "",
   label: "",
   milestone: "",
   open: false,
   commentAuthor: "",
}

```
- fetchData 함수 내에서 response 받은 데이터를 선택된 필터에 맞게 필터링 한 후(pipe함수 이용) setState 하려 했으나 json객체 depth가 너무 깊어서 잠시 포기 ㅎ 넘 까다로움
--- 
질문 

- 열린 마일스톤 닫힌 마일스톤 기능 추가 안 한다면 그냥 마일스톤 개수 보여주는 걸로 바꾸는 게 어떠신감???
![image](https://user-images.githubusercontent.com/56783350/126042946-e3899944-b18b-489d-af9f-2ba94c0e6dc2.png)
